### PR TITLE
Fix link hovering causing increased width

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,14 @@
+---
+---
+
+@import "{{ site.theme }}";
+
+/**
+ * Remove theme's bolding effect of links on hover, causing the width of the
+ * text to increase, causing lines to shift. Instead, emulate the visual effect
+ * of bolding without modifying text size.
+ */
+a:hover {
+  font-weight: unset;
+  text-shadow: 0px 0px 1px #069;
+}


### PR DESCRIPTION
Fix the hover state of links causing an increase in width, causing the lines of text in the paragraph to move lines. When a link is hovered, the theme by default changes its font weight to bold. The increase in font weight causes the width of the element's text to also increase, causing words to shift down a line. By instead unsetting the font width, a text shadow of 1 pixel can be set to emulate the effect of bolding without actually increasing the font weight.

This fixes text like so (note the newlines):

```
Mantaro is a simple but powerful Discord bot used to enhance your Discord
experience. It includes many fun and useful features such as moderation,
music, games and currency. It’s currently in over 500,000 servers serving
over 35 million users!
```

from changing to this on hover:

```
Mantaro is a simple but powerful Discord bot used to enhance your
Discord experience. It includes many fun and useful features such as
moderation, music, games and currency. It’s currently in over 500,000
servers serving over 35 million users!
```

Normal state without hover:
![image](https://user-images.githubusercontent.com/57759500/97379797-043cf280-189c-11eb-8252-ad63435f6848.png)

Before on hover:
![image](https://user-images.githubusercontent.com/57759500/97379782-f4251300-189b-11eb-8798-5aad5c1ed73e.png)

After on hover:
![image](https://user-images.githubusercontent.com/57759500/97379770-ec656e80-189b-11eb-868e-2f89cf0ebda8.png)
